### PR TITLE
Fix three critical code bugs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,10 @@
 import type { Metadata } from 'next';
+import '@/index.css';
+// Import development-only styles safely (ignored in prod builds)
+if (process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  import('@/index.dev.css');
+}
 
 export const metadata: Metadata = {
   title: 'Apt SqFt - Floor Plan Designer',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,6 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import '@/index.css';
-
-// Import development-only styles
-if (process.env.NODE_ENV === 'development') {
-  import('@/index.dev.css');
-}
 
 const App = dynamic(() => import('@/App'), {
   ssr: false,

--- a/src/components/LayoutEditor.tsx
+++ b/src/components/LayoutEditor.tsx
@@ -360,11 +360,13 @@ export const LayoutEditor: React.FC<LayoutEditorProps> = ({
 
           // Adjust position for west and north walls after snapping
           if (resizeWall === 'w') {
-            const widthDiff = snappedWidth - selectedItem.width;
+            // When width decreases after snapping, x should move right (dx positive); when it increases, x moves left (dx negative)
+            const widthDiff = selectedItem.width - snappedWidth;
             snappedX = selectedItem.x + widthDiff;
           }
           if (resizeWall === 'n') {
-            const heightDiff = snappedHeight - selectedItem.height;
+            // When height decreases after snapping, y should move down (dy positive); when it increases, y moves up (dy negative)
+            const heightDiff = selectedItem.height - snappedHeight;
             snappedY = selectedItem.y + heightDiff;
           }
 

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -203,7 +203,7 @@ export function RightSidebar({
         )}
         {sidebarTab === 4 && (
           <>
-            {selectedRoom ? (
+            {selectedFurniture ? (
               selectedTool === 'edit' ? (
                 <Box>
                   <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
@@ -216,14 +216,14 @@ export function RightSidebar({
                   </Box>
                   <FurnitureForm
                     onSubmit={handleUpdateFurniture}
-                    initialValues={selectedRoom}
+                    initialValues={selectedFurniture}
                     onDelete={handleDeleteFurniture}
                     onDuplicate={handleDuplicateFurniture}
                   />
                 </Box>
               ) : (
                 <RoomDetails
-                  room={selectedRoom}
+                  room={selectedFurniture}
                   onEdit={() => onToolChange('edit')}
                   onSwapDimensions={onSwapDimensions}
                 />

--- a/src/lib/hooks/useLocalStoragePersistence.ts
+++ b/src/lib/hooks/useLocalStoragePersistence.ts
@@ -85,15 +85,27 @@ export const useLocalStoragePersistence = ({
 
 // Helper function to initialize state from localStorage
 export const initializeStateFromStorage = () => {
-  // Initialize floor plans
+  // Initialize floor plans with safe parsing
   const savedFloorPlans = localStorage.getItem('floorPlans');
-  const floorPlans = savedFloorPlans
-    ? JSON.parse(savedFloorPlans)
-    : { Untitled: initialFloorPlan };
+  let floorPlans: { [key: string]: FloorPlan } = { Untitled: initialFloorPlan };
+  if (savedFloorPlans) {
+    try {
+      const parsed = JSON.parse(savedFloorPlans);
+      if (parsed && typeof parsed === 'object') {
+        floorPlans = parsed;
+      }
+    } catch (e) {
+      console.warn('Error parsing saved floorPlans, using default:', e);
+      localStorage.removeItem('floorPlans');
+    }
+  }
 
   // Initialize current floor plan name
   const savedCurrentName = localStorage.getItem('currentFloorPlanName');
-  const currentFloorPlanName = savedCurrentName || 'Untitled';
+  const currentFloorPlanName =
+    savedCurrentName && floorPlans[savedCurrentName]
+      ? savedCurrentName
+      : 'Untitled';
 
   // Initialize app state
   const savedState = localStorage.getItem('appState');

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,2 @@
+declare module '*.css';
+


### PR DESCRIPTION
Fixes furniture editing logic, corrects snap-to-grid position adjustments, and hardens local storage initialization.

The furniture editing tab was incorrectly binding to `selectedRoom` instead of `selectedFurniture`, causing the wrong form and values to display. Additionally, west and north resizes had a logic error where the post-snap position adjustment used the wrong sign, causing incorrect element shifts. Finally, `initializeStateFromStorage` lacked safe parsing for `floorPlans` and robust validation for `currentFloorPlanName`, which could lead to app crashes or broken states with corrupted local storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bc3c14c-f2de-4c68-a0d9-c2d9f66a5770">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1bc3c14c-f2de-4c68-a0d9-c2d9f66a5770">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

